### PR TITLE
Added path exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ git clone https://github.com/Philippe-cheype/Prep.git prep && cd prep && sudo ./
 ## Usage
 
 ```
-prep [-hvfSU]
+prep [-hvfSU] [<exclude-path>...]
 A collection of useful tools for working with Epitech-like projects.
 
 USAGE:
@@ -41,6 +41,8 @@ USAGE:
         -f --force      Force prep execution even if the working directory doesn't contain any Makefile
         -S --no-screen  Disable the terminal screening behavior
         -U --no-update  Disable the update check
+        
+        exclude-path    The files/directories to exclude from the prep analyse
 ```
 
 For safety reasons prep won't execute in a folder not containing a Makefile, you can still force it using
@@ -48,6 +50,12 @@ the `-f` flag
 
 
 > <span style="color:red">Make sure you are not about to lose files before executing this!</span>
+
+
+Please notice that adding path to exclude from analyse will copy the whole directory to a temporary 
+one, so it's recommended to use it only with small projects.
+Also, the make fclean and unnecessary files removal will be executed in the original directory, **without 
+the exclusion**. Be careful when using this option!
 
 ## Tools used
 

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ git clone https://github.com/Philippe-cheype/Prep.git prep && cd prep && sudo ./
 ## Usage
 
 ```
-prep [-h] [-V] [-f] [-S] [-U]
+prep [-hvfSU]
 A collection of useful tools for working with Epitech-like projects.
 
 USAGE:
         -h --help       Display this help message
-        -V --version    Display the actual Prep version
+        -v --version    Display the actual Prep version
         -f --force      Force prep execution even if the working directory doesn't contain any Makefile
         -S --no-screen  Disable the terminal screening behavior
         -U --no-update  Disable the update check
@@ -47,7 +47,7 @@ For safety reasons prep won't execute in a folder not containing a Makefile, you
 the `-f` flag
 
 
-> <span style="color:red">Make sure you are not about to loose files before executing this!</span>
+> <span style="color:red">Make sure you are not about to lose files before executing this!</span>
 
 ## Tools used
 
@@ -65,4 +65,4 @@ All that I'm doing is putting them together in a simple script.
 
 Special Thanks to Kyrela, a guy in my class who came up to me saying that
 they've been using my script for some time now.
-He's given me some help and motivation to keep maintaing this!
+He's given me some help and motivation to keep maintaining this!

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ the `-f` flag
 
 > <span style="color:red">Make sure you are not about to lose files before executing this!</span>
 
+The exclude-path options support wildcards, for example:
+
+``` bash
+prep -f cmake*/
+```
 
 Please notice that adding path to exclude from analyse will copy the whole directory to a temporary 
 one, so it's recommended to use it only with small projects.

--- a/install.sh
+++ b/install.sh
@@ -200,4 +200,4 @@ fi
 
 echo "Prep installed!"
 echo "To use it, just call 'prep'"
-echo "Usage: prep [-hvfSU]"
+echo "Usage: prep [-hvfSU] [<exclude-path>...]"

--- a/prep.sh
+++ b/prep.sh
@@ -24,11 +24,29 @@ PREP_NEW_VERSION="$PREP_VERSION"
 
 trap ctrl_c INT
 
-function ctrl_c() {
-  tput rmcup
+ctrl_c() {
+  if [ "$S" == 0 ]; then tput rmcup; fi
   echo "Stopping prep execution..."
   rm -rf /tmp/prep_temp
   exit 1
+}
+
+run_program() {
+  if [ "$S" == 0 ]; then clear; fi
+  prg="$1" prg_name="$2" prg_url="$3" completion_msg="$4"
+  if ( ! type "$prg" &> /dev/null )
+  then
+    echo "$prg_name wasn't found. Please re-install Prep or install $prg_name manually."
+    echo "- Prep: https://github.com/Philippe-cheype/Prep"
+    echo "- $prg_name: $prg_url"
+    return 1
+  fi
+
+  shift; shift; shift; shift
+  "$prg" "$@"
+  echo -e "$completion_msg"
+  read -r
+  return 0
 }
 
 
@@ -170,69 +188,14 @@ fi
 
 
 
-# ============================================= NormEZ ============================================= #
-if [ $S == 0 ]; then clear; fi
-if type normez &> /dev/null
-then
-  normez
-  echo -e "\nNormEZ done."
-else
-  echo "NormEZ wasn't found. Please re-install Prep or install NormEZ manually."
-  echo "- Prep: https://github.com/Philippe-cheype/Prep"
-  echo "- NormEZ: https://github.com/ronanboiteau/NormEZ/"
-fi
-echo "Press enter to continue..."
-read -r
+# ============================================ Programs ============================================ #
+run_program normez "NormEZ" "https://github.com/ronanboiteau/NormEZ/" "Press enter to continue..."
+run_program bubulle "Bubulle" "https://github.com/aureliancnx/Bubulle-Norminette/" "Press enter to continue..."
+run_program cppcheck "CppCheck" "http://cppcheck.sourceforge.net/" "Press enter to continue..." -q .
+run_program deheader "Deheader" "https://gitlab.com/esr/deheader/" "Prep finished.\nPress enter to exit...."
 
 
 
-# ============================================= Bubulle ============================================ #
-if [ $S == 0 ]; then clear; fi
-if type bubulle &> /dev/null
-then
-  bubulle
-  echo -e "\nBubulle done."
-else
-  echo "Bubulle wasn't found. Please re-install Prep or install Bubulle manually."
-  echo "- Prep: https://github.com/Philippe-cheype/Prep"
-  echo "- Bubulle: https://github.com/aureliancnx/Bubulle-Norminette/"
-fi
-echo "Press enter to continue..."
-read -r
-
-
-
-# ============================================ CppCheck ============================================ #
-if [ $S == 0 ]; then clear; fi
-if type cppcheck &> /dev/null
-then
-  cppcheck -q .
-  echo -e "\nCppcheck done."
-else
-  echo "cppcheck wasn't found. Please re-install Prep or install cppcheck manually."
-  echo "- Prep: https://github.com/Philippe-cheype/Prep"
-  echo "- cppcheck: http://cppcheck.sourceforge.net/"
-fi
-echo "Press enter to continue..."
-read -r
-
-
-
-# =========================================== Deheader ============================================= #
-if [ $S == 0 ]; then clear; fi
-if type deheader &> /dev/null
-then
-  deheader
-  echo -e "\nDeheader done."
-else
-  echo "deheader wasn't found. Please re-install Prep or install deheader manually."
-  echo "- Prep: https://github.com/Philippe-cheype/Prep"
-  echo "- deheader: https://gitlab.com/esr/deheader/"
-fi
-echo -e "Prep finished.\nPress enter to exit..."
-read -r
-
-
-
+# ============================================ Cleanup ============================================= #
 rm -rf /tmp/prep_temp
-tput rmcup
+if [ $S == 0 ]; then tput rmcup; fi


### PR DESCRIPTION
### Added path exclusion
closes #6 
Added possibility to exclude files/directories on Prep analyse by copying the files to a temporary path (as some utilities don't support exclusion)

Syntax:
```
prep [-hvfSU] [<exclude-path>...]
A collection of useful tools for working with Epitech-like projects.
USAGE:
        -h --help       Display this help message
        -v --version    Display the actual Prep version
        -f --force      Force prep execution even if the working directory doesn't contain any Makefile
        -S --no-screen  Disable the terminal screening behavior
        -U --no-update  Disable the update check

        exclude-path    The files/directories to exclude from the prep analyse
```
Example:
```bash
prep cmake ressources -S
```

Exclusion also supports wildcard.

Please notice that adding path to exclude from analyse will copy the whole directory to a temporary one, so it's recommended to use it only with small projects. Also, the make fclean and unnecessary files removal will be executed in the original directory, without the exclusion.

### Other
- Fixed some typos
- Updated help messages
- Added ^C catch to exit Prep properly
- Created function run_program to avoid redundant code
- Updated README to add informations about path exclusion